### PR TITLE
Set type=module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "js-fatfs",
+  "type": "module",
   "version": "0.1.0",
   "author": "irori <irorin@gmail.com>",
   "repository": {


### PR DESCRIPTION
This package uses ESM (the wasm build uses `EXPORT_ES6` and the `import` variable is used in `dist/fatfs.js`), however the `package.json` file doesn't contain `"type": "module"`, so when I try to run this package it fails with:

```
/Users/cosmotherly/atlassian/src/nxkit/node_modules/js-fatfs/dist/fatfs.js:3
  var _scriptDir = import.meta.url;
                          ^^^^

SyntaxError: Cannot use 'import.meta' outside a module
```

So this PR sets `"type": "module"` in the `package.json` to fix it.